### PR TITLE
Pull in Upstream Updates and Alphabetize `apt` Packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,10 +8,19 @@ ENV pip_packages "ansible cryptography"
 # Install dependencies.
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
-       sudo systemd systemd-sysv \
-       build-essential wget libffi-dev libssl-dev \
-       python3-pip python3-dev python3-setuptools python3-wheel python3-apt \
+       build-essential \
        iproute2 \
+       libffi-dev \
+       libssl-dev \
+       python3-apt \
+       python3-dev \
+       python3-pip \
+       python3-setuptools \
+       python3-wheel \
+       sudo \
+       systemd \
+       systemd-sysv \
+       wget \
     && rm -rf /var/lib/apt/lists/* \
     && rm -Rf /usr/share/doc && rm -Rf /usr/share/man \
     && apt-get clean


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This PR pulls in changes from [geerlingguy/docker-debian11-ansible](https://github.com/geerlingguy/docker-debian11-ansible) (which this project is based on) and reorganizes the packages to be installed using `apt-get`.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

It's good to stay up-to-date with "upstream" changes. Reorganizing the `apt-get` packages to install improves readability and aligns with changes we previously made in https://github.com/cisagov/docker-debian11-ansible/commit/8285ee625066bdc21749e80ac43a78630c005c0d.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
There is no testing configured for this repository so my testing is limited to successfully building and testing the Docker image locally:

```console
$ docker run --detach --privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro cisagov/docker-debian12-ansible:testing
5955d03d0fc722f41bed41fdbc97f2fb04743f51f00c950426bee7e3e4783003
$ docker exec --tty 5955d03d0fc722f41bed41fdbc97f2fb04743f51f00c950426bee7e3e4783003 env TERM=xterm ansible --version
ansible [core 2.11.6]
  config file = None
  configured module search path = ['/root/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python3.9/dist-packages/ansible
  ansible collection location = /root/.ansible/collections:/usr/share/ansible/collections
  executable location = /usr/local/bin/ansible
  python version = 3.9.7 (default, Sep 24 2021, 09:43:00) [GCC 10.3.0]
  jinja version = 3.0.2
  libyaml = True
```
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

## ✅ Checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - _eschew scope creep!_
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
