### PR TITLE
Update GitHub Actions workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,10 +19,10 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Test building image.
-        run: docker build -t docker-ansible .
+        run: docker build --tag docker-ansible .
 
       - name: Run the built image.
-        run: docker run --name test-container -d --privileged --cgroupns=host -v /sys/fs/cgroup:/sys/fs/cgroup:rw docker-ansible
+        run: docker run --name test-container --detach --privileged --cgroupns host --volume /sys/fs/cgroup:/sys/fs/cgroup:rw docker-ansible
 
       - name: Verify Ansible is accessible in the built image.
         run: docker exec --tty test-container env TERM=xterm ansible --version

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
         run: docker build -t docker-ansible .
 
       - name: Run the built image.
-        run: docker run --name test-container -d --privileged -v /sys/fs/cgroup:/sys/fs/cgroup:ro docker-ansible
+        run: docker run --name test-container -d --privileged --cgroupns=host -v /sys/fs/cgroup:/sys/fs/cgroup:rw docker-ansible
 
       - name: Verify Ansible is accessible in the built image.
         run: docker exec --tty test-container env TERM=xterm ansible --version

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Test building image.
         run: docker build -t docker-ansible .
@@ -35,9 +35,9 @@ jobs:
     if: github.ref == 'refs/heads/master'
 
     steps:
-      - uses: actions/checkout@v2
-      - uses: docker/setup-qemu-action@v1
-      - uses: docker/setup-buildx-action@v1
+      - uses: actions/checkout@v3
+      - uses: docker/setup-qemu-action@v2
+      - uses: docker/setup-buildx-action@v2
 
       - name: Login to Docker Hub
         uses: docker/login-action@v1
@@ -46,7 +46,7 @@ jobs:
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Build and push image.
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           context: ./
           file: Dockerfile

--- a/README.md
+++ b/README.md
@@ -14,13 +14,13 @@ This image is built on Docker Hub automatically any time the upstream OS contain
 
   1. [Install Docker](https://docs.docker.com/engine/installation/).
   2. `cd` into this directory.
-  3. Run `docker build -t debian12-ansible .`
+  3. Run `docker build --tag cisagov/docker-debian12-ansible .`
 
 ## How to Use ##
 
   1. [Install Docker](https://docs.docker.com/engine/installation/).
-  2. Pull this image from Docker Hub: `docker pull cisagov/docker-debian12-ansible:latest` (or use the image you built earlier, e.g. `debian12-ansible`).
-  3. Run a container from the image: `docker run --detach --privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro cisagov/docker-debian12-ansible:latest`.
+  2. Pull this image from Docker Hub: `docker pull cisagov/docker-debian12-ansible:latest` (or use the image you built earlier, e.g. `cisagov/docker-debian12-ansible`).
+  3. Run a container from the image: `docker run --detach --privileged --cgroupns=host --volume=/sys/fs/cgroup:/sys/fs/cgroup:rw cisagov/docker-debian12-ansible:latest`.
   4. Use Ansible inside the container:
     a. `docker exec --tty [container_id] env TERM=xterm ansible --version`
     b. `docker exec --tty [container_id] env TERM=xterm ansible-playbook /path/to/ansible/playbook.yml --syntax-check`


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request updates the Actions versions used in the `build.yml` workflow to their latest major versions. It also updates the command used to run the testing image.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

Updating the Actions versions is just maintenance. The Docker command needed to be updated because of changes in cgroups. Ubuntu 20.04 uses cgroups v1 while 22.04 uses csgroups v2. The biggest change is that the default cgroup namespace is `host` in v1 and `private` in v2. In addition to setting the appropriate cgroup namespace we also need to set the cgroup volume mount as read-write instead of read-only. 
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests pass. This is the same set of changes made in https://github.com/cisagov/docker-kali-ansible/pull/4 so it should be in the clear.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.
