### PR TITLE
Use the `--break-system-packages` flag when installing packages with `pip`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,10 +27,10 @@ RUN apt-get update \
     && apt-get clean
 
 # Upgrade pip to latest version.
-RUN pip3 install --upgrade pip
+RUN pip3 install --break-system-packages --upgrade pip
 
 # Install Ansible via pip.
-RUN pip3 install $pip_packages
+RUN pip3 install --break-system-packages $pip_packages
 
 COPY initctl_faker .
 RUN chmod +x initctl_faker && rm -fr /sbin/initctl && ln -s /initctl_faker /sbin/initctl


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request updates the image configuration to use the `--break-system-packages` flag when installing packages with `pip`. This PR will I believe replace #4 as a better solution.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

Debian 12 (Bookworm) is now configuring its Python base environment as "externally managed" per [PEP 668](https://peps.python.org/pep-0668/). As a result you can only install system Python packages from apt packages. Any non-apt Python packages must be installed using a Python virtual environment _or_ alternatively one can use the `--break-system-packages` flag to force installation into the system Python environment. Since this image is supposed to represent Debian 12 for Ansible testing it makes sense to force installation of necessary packages to the system Python environment instead of using a virtual environment as I configured in #4. This will ensure that Ansible roles that support Debian 12 that use this image for testing will correctly handle the externally managed Python environment.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Mirroring what is done in the [GitHub Actions workflow](https://github.com/cisagov/docker-debian12-ansible/blob/654cf8700563d9fdf5f2453991d38a3302ba2433/.github/workflows/build.yml#L21-L28) I verified that I could:
1. Build the image successfully.
2. Start the image successfully.
3. Get the version of Ansible from the running container.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
