### PR TITLE
Only install `pip` with the system package manager

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,9 +26,6 @@ RUN apt-get update \
     && rm -Rf /usr/share/doc && rm -Rf /usr/share/man \
     && apt-get clean
 
-# Upgrade pip to latest version.
-RUN pip3 install --break-system-packages --upgrade pip
-
 # Install Ansible via pip.
 RUN pip3 install --break-system-packages $pip_packages
 


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request removes the instruction to upgrade the [pip] package from Python. This leaves only the version of [pip] installed by `apt` from the `python3-pip` package.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

Upgrading the version of [pip] outside of that offered by `apt` does not properly represent a base Debian 12 (Bookworm) system for testing. This is especially important since Debian Bookworm is the first Debian release that will leverage [PEP-668](https://peps.python.org/pep-0668/) to mark the system Python environment as externally managed.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

I tested a locally built image to ensure that the version of [pip] installed matched the one offered by `apt` (this is the same as the latest version so it's not particularly useful in this case) and verified the path of the `pip3` script (`/usr/bin/pip3` vs. `/usr/local/bin/pip3`).
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.

[pip]: https://pypi.org/project/pip/
